### PR TITLE
refactor: make clean command compatible with macOS

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -16,7 +16,6 @@ manage-start:
 shell:
     python manage.py shell_plus
 
-[linux]
 clean:
     find . -path "./apps/*/migrations/*.py" -not -name "__init__.py" -delete
     python manage.py clean_pyc

--- a/.justfile
+++ b/.justfile
@@ -16,6 +16,8 @@ manage-start:
 shell:
     python manage.py shell_plus
 
+[linux]
+[macos]
 clean:
     find . -path "./apps/*/migrations/*.py" -not -name "__init__.py" -delete
     python manage.py clean_pyc


### PR DESCRIPTION
### Description
This pull request removes the platform-specific [linux] tag from the clean command in our makefile to ensure compatibility with macOS. This change allows the same command to be executed seamlessly on both Linux and macOS systems, enhancing the development process across different environments.

### Related Issue
N/A

### Type of change
- [x] Enhancement

### Checklist
- [x] Local changes have been reviewed and successfully tested.
- [x] Coding style and formatting have been followed in line with the project.
- [x] All tests have been run and no failures occurred.

### Additional Notes
N/A